### PR TITLE
feat(invoices): connect Invoices page to API — list/search/pagination

### DIFF
--- a/frontend/src/lib/invoices.js
+++ b/frontend/src/lib/invoices.js
@@ -1,22 +1,31 @@
-// Simple helper para listar facturas desde /api/invoices
-export async function listInvoices({ page = 1, limit = 25, q = "" } = {}, token) {
+// src/lib/invoices.js
+// Cliente ligero para el API de facturas
+
+export async function listInvoices({ q = "", page = 1, limit = 10 } = {}) {
   const params = new URLSearchParams();
+  if (q) params.set("q", q);
   params.set("page", page);
   params.set("limit", limit);
-  if (q) params.set("q", q);
 
   const res = await fetch(`/api/invoices?${params.toString()}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
+    headers: { Accept: "application/json" },
     credentials: "include",
   });
 
   if (!res.ok) {
-    const txt = await res.text().catch(() => "");
-    throw new Error(`Failed to load invoices (${res.status}) ${txt}`);
+    const text = await res.text().catch(() => "");
+    throw new Error(`GET /api/invoices -> ${res.status}: ${text}`);
   }
-  return res.json(); // espera {items, page, totalPages, ...} o un array; abajo manejamos ambos casos
+  // Esperado:
+  // { items: [...], page: 1, totalPages: 1, total: 0 }
+  return res.json();
+}
+
+export async function getInvoice(id) {
+  const res = await fetch(`/api/invoices/${id}`, {
+    headers: { Accept: "application/json" },
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(`GET /api/invoices/${id} -> ${res.status}`);
+  return res.json();
 }


### PR DESCRIPTION
Adds the first functional version of the Invoices page.

Changes
- Wire `frontend/src/pages/Invoices.jsx` to the data layer
- Use `listInvoices({ q, page, limit })`
- Basic table with columns + empty state
- Search box (“q”) and client-side pager (page/limit)
- Loading and error handling
- Keeps BASE_URL/BASE_PATH-safe URLs (no trailing slashes)

Notes
- No backend changes in this PR
- This PR should be merged BEFORE the next UI polish PR
- CI: Frontend Build & Deploy should be green; smoke tests unaffected

Manual check
1) Go to /v2/invoices (prod) or /v2-staging/invoices (staging)
2) Use the search box and change page/limit
3) Verify loading states, empty state and error banner